### PR TITLE
Drop duplicated rows based on transformation groups

### DIFF
--- a/R/sensors.R
+++ b/R/sensors.R
@@ -37,9 +37,11 @@ sensor_features <- function(sensor_data, transform = NULL, extract = NULL,
     return(features)
   }
   if (!is.null(extract) && !is.null(extract_on)) {
+    transformed_sensor_data_groups <- dplyr::groups(transformed_sensor_data)
     features$extracted_features <- purrr::map_dfr(
       extract_on,
-      ~ extract_features(transformed_sensor_data, ., extract))
+      ~ extract_features(transformed_sensor_data, ., extract)) %>% 
+      dplyr::distinct(!!!transformed_sensor_data_groups, measurementType, .keep_all = T)
   }
   if (!is.null(models)) {
     features$model_features <- purrr::map(models, ~ .(transformed_sensor_data))
@@ -77,9 +79,10 @@ kinematic_sensor_features <- function(sensor_data, acf_col = NULL, transform = N
   }
   transformed_sensor_data <- transform(sensor_data)
   if (!is.null(extract) && !is.null(extract_on)) {
+    transformed_sensor_data_groups <- dplyr::groups(transformed_sensor_data)
     incidental_cols_to_preserve <- transformed_sensor_data %>%
       dplyr::select(-dplyr::one_of(extract_on)) %>%
-      dplyr::distinct() # distinct of group (table index) cols and incidental cols
+      dplyr::distinct(!!!transformed_sensor_data_groups, .keep_all = T)
     movement_features <- sensor_features(
       sensor_data = transformed_sensor_data,
       transform = NULL,

--- a/man/calculate_acf.Rd
+++ b/man/calculate_acf.Rd
@@ -12,7 +12,7 @@ calculate_acf(sensor_data, col)
 \item{col}{Name of column to calculate acf of.}
 }
 \value{
-A tibble with columns axis, window, window_index, acf
+A tibble with columns axis, window, acf
 }
 \description{
 Estimate the ACF for windowed sensor data.

--- a/man/transform_gyroscope_data.Rd
+++ b/man/transform_gyroscope_data.Rd
@@ -4,7 +4,7 @@
 \alias{transform_gyroscope_data}
 \title{Prepare gyroscope sensor data for feature extraction}
 \usage{
-transform_gyroscope_data(sensor_data, transformation = NA,
+transform_gyroscope_data(sensor_data, transformation = NULL,
   window_length = 256, time_range = c(1, 9), frequency_range = c(1, 25),
   sampling_rate = 100)
 }

--- a/man/window.Rd
+++ b/man/window.Rd
@@ -12,9 +12,6 @@ window(sensor_data, window_length, overlap)
 \item{window_length}{Length of the filter}
 
 \item{overlap}{window overlap}
-
-\item{include_timestamp}{Whether to include columns for starting and ending
-timestamps for each row.}
 }
 \value{
 Windowed sensor data


### PR DESCRIPTION
Resolves #68 

Feature functions used to return a multi-thousand row feature dataframe, but most of these rows were duplicates, since we are only computing features at the group level (determined by the transformation chosen). Now assay-level feature extraction functions return a much more concise 150-row dataframe (when using `default_kinematic_features`).

I've also stopped returning the window index in `window`. Mostly because it didn't provide any useful information when used as part of a feature extraction function and awkward to get rid of later on when dropping duplicated rows.